### PR TITLE
order tables alphabetically and bump version

### DIFF
--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -68,7 +68,7 @@ class PostgresToRedshift
   end
 
   def tables(except: [])
-    source_connection.exec("SELECT * FROM information_schema.tables WHERE table_schema = 'public' AND table_type in ('BASE TABLE', 'VIEW')").map do |table_attributes|
+    source_connection.exec("SELECT * FROM information_schema.tables WHERE table_schema = 'public' AND table_type in ('BASE TABLE', 'VIEW') ORDER BY table_name ASC").map do |table_attributes|
       table = Table.new(attributes: table_attributes)
       next if except.include?(table.name) || table.name =~ /^pg_/
       table.columns = column_definitions(table)

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 class PostgresToRedshift
-  VERSION = "0.2.1"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
When tracing the run via logs it would be helpful to get a sense of progress and see where it blew up by having the tables predictably in alphabetical order.